### PR TITLE
Migrate to Go Modules

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,14 +4,8 @@
 
 with import nixpkgs { inherit system; };
 
-stdenv.mkDerivation {
+buildGoModule {
   name = "nixos-shell";
   src = ./.;
-  buildInputs = [ go ];
-  phases = [ "buildPhase" ];
-  buildPhase = 
-    ''
-    mkdir -p $out/bin
-    GOPATH=$src go build -o $out/bin/nixos-shell nixos-shell
-    '';
+  vendorSha256 = "0gjj1zn29vyx704y91g77zrs770y2rakksnn9dhg8r6na94njh5a";
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/chrisfarms/nixos-shell
+
+go 1.17
+
+require github.com/jessevdk/go-flags v1.5.0
+
+require golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -2,29 +2,30 @@ package main
 
 import (
 	"crypto/rand"
+	"encoding/base32"
 	"fmt"
-	"github.com/jessevdk/go-flags"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path"
 	"path/filepath"
-	"strings"
 	"strconv"
-	"io/ioutil"
+	"strings"
 	"syscall"
 	"time"
-	"encoding/base32"
+
+	"github.com/jessevdk/go-flags"
 )
 
 // Generate a random id for the container name.
 // This name can't be too long as it is used as
-// an interface name as well which will explode if 
+// an interface name as well which will explode if
 // is larger than 6 bytes for some reason.
 // Clashes are possible here so this checks against
 // known container names to ensure it's unique
 func randomName() (string, error) {
-	for i := 0; i<25; i++ {
+	for i := 0; i < 25; i++ {
 		b := make([]byte, 6)
 		_, err := rand.Read(b)
 		if err != nil {
@@ -56,7 +57,7 @@ type Cmd struct {
 	Timeout int      `short:"t" description:"timeout in seconds to wait for container boot" default:"90"`
 	Ports   []string `short:"p" long:"port" description:"expose a container port to the host. example '8080:80' allows access to container port 80 via host port 8080"`
 	sigint  chan bool
-	netenv map[string]string
+	netenv  map[string]string
 }
 
 // logging
@@ -116,7 +117,7 @@ func (cmd *Cmd) Create(confpath string) (keyPath string, err error) {
 			''
 			cd /src
 			'';
-	`, confpath, pub, )
+	`, confpath, pub)
 	err = cmd.container(false, "create", cmd.Id, "--config", module)
 	if err != nil {
 		return "", err
@@ -192,7 +193,7 @@ func (cmd *Cmd) keygen() (private string, public string, err error) {
 		return
 	}
 	keyPath := path.Join(home, "id_rsa")
-	args := []string{ "-t", "rsa", "-N", "", "-f",  keyPath }
+	args := []string{"-t", "rsa", "-N", "", "-f", keyPath}
 	cmd.debug(exe, args)
 	c := exec.Command(exe, args...)
 	if cmd.Verbose {
@@ -204,7 +205,7 @@ func (cmd *Cmd) keygen() (private string, public string, err error) {
 	if err != nil {
 		return
 	}
-	return keyPath, keyPath+".pub", nil
+	return keyPath, keyPath + ".pub", nil
 }
 
 // wrapper around ssh
@@ -467,7 +468,7 @@ func (cmd *Cmd) Execute() error {
 			fmt.Fprintf(os.Stderr, "failed to destroy container %s\n", cmd.Id)
 		}
 	}()
-	key, err := cmd.Create(confpath); 
+	key, err := cmd.Create(confpath)
 	if err != nil {
 		return err
 	}

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/gza2bw1c2lz58qxxsdx6f79njwkpjshj-nixos-shell


### PR DESCRIPTION
This PR migrates the project to Go Modules. `default.nix` is modified to also support that. A `vendorSha256` is added inside and must be updated manually every time `go.mod` is changed.